### PR TITLE
Issue #9 - Removing CamelCase from request params

### DIFF
--- a/src/controllers/notesController.js
+++ b/src/controllers/notesController.js
@@ -29,7 +29,7 @@ function getDefaultJoiNoteSchema () {
   return Joi.object().keys({
     description: Joi.string().required(),
     user: Joi.string().required(),
-    sessionId: Joi.string().required(),
+    session_id: Joi.string().required(),
     topic: Joi.string().required()
   })
 }
@@ -38,7 +38,7 @@ function getDefaultNoteFromRequest (req) {
   return {
     description: req.body.description,
     user: req.body.user,
-    sessionId: req.body.sessionId,
+    sessionId: req.body.session_id,
     topic: req.body.topic
   }
 }
@@ -50,7 +50,7 @@ module.exports = function (proxy) {
     }
 
     getNotesFromSession (req, res) {
-      var sessionId = req.params.sessionId
+      var sessionId = req.params.session_id
       proxy.getNotes(sessionId, res, snapshotCallback)
     }
 

--- a/src/controllers/sessionsController.js
+++ b/src/controllers/sessionsController.js
@@ -16,7 +16,8 @@ module.exports = function (proxy) {
     }
 
     getSession (req, res) {
-      var sessionId = req.params.sessionId
+      var sessionId = req.params.session_id
+      console.log(sessionId)
       proxy.getSession(sessionId, res, dataCallback)
     }
 

--- a/src/environment/router/notesRouter.js
+++ b/src/environment/router/notesRouter.js
@@ -2,7 +2,7 @@ const express = require('express')
 var app = express()
 
 module.exports = function (notesController) {
-  app.get('/:sessionId', (req, res) => {
+  app.get('/:session_id', (req, res) => {
     notesController.getNotesFromSession(req, res)
   })
 

--- a/src/environment/router/sessionsRouter.js
+++ b/src/environment/router/sessionsRouter.js
@@ -2,7 +2,7 @@ const express = require('express')
 var app = express()
 
 module.exports = function (sessionsController) {
-  app.get('/:sessionId', (req, res) => {
+  app.get('/:session_id', (req, res) => {
     sessionsController.getSession(req, res)
   })
 


### PR DESCRIPTION
Parameters that come from a request should not be in CamelCase so
it was changed to underscore case.

If fixes #9.