### PR TITLE
Issue #13 - Topics was not defined when creating a Session

### DIFF
--- a/src/controllers/sessionsController.js
+++ b/src/controllers/sessionsController.js
@@ -29,7 +29,7 @@ module.exports = function (proxy) {
     }
 
     createSession (req, res) {
-      var topics = req.body.topics
+      const topics = req.body
       Joi.validate(topics, Joi.array().items(Joi.string()), function (err, value) {
         if (err) {
           res.send(err)


### PR DESCRIPTION
The server was expecting an object "topics" that received an
array of strings but the client-side is sending the information
directly. So we can get the body from the request directly.

It fixes #13.