### PR TITLE
Issue #9 - Changing some leftover camel cases

### DIFF
--- a/src/controllers/notesController.js
+++ b/src/controllers/notesController.js
@@ -28,7 +28,7 @@ function getDefaultJoiNoteSchema () {
   return Joi.object().keys({
     description: Joi.string().required(),
     user: Joi.string().required(),
-    sessionId: Joi.string().required(),
+    session_id: Joi.string().required(),
     topic: Joi.string().required()
   })
 }
@@ -37,7 +37,7 @@ function getDefaultNoteFromRequest (req) {
   return {
     description: req.body.description,
     user: req.body.user,
-    sessionId: req.body.session_id,
+    session_id: req.body.session_id,
     topic: req.body.topic
   }
 }

--- a/src/environment/FirestoreDB/index.js
+++ b/src/environment/FirestoreDB/index.js
@@ -12,7 +12,7 @@ var FieldValue = require('firebase-admin').firestore.FieldValue
 
 const tableInfo = {
   table_notes: 'notes',
-  column_notes_session_id: 'sessionId',
+  column_notes_session_id: 'session_id',
   column_notes_description: 'description',
   table_sessions: 'sessions'
 }


### PR DESCRIPTION
There was still some Camel Cases in the notes controller which
was causing the Joi validation to fail.

Now the id of the session will be defined as "session_id" even
in the database.

It fixes #9.