### PR TITLE
Issue #11 - Send response as error when requests fails

### DIFF
--- a/src/controllers/notesController.js
+++ b/src/controllers/notesController.js
@@ -2,8 +2,8 @@ const Joi = require('joi')
 
 var snapshotCallback = function (err, snapshot, res) {
   if (err) {
-    console.err(err)
-    res.send('ERROR!')
+    res.status(503)
+    res.send(err)
     return
   }
 
@@ -17,8 +17,8 @@ var snapshotCallback = function (err, snapshot, res) {
 
 var dataCallback = function (err, data, res) {
   if (err) {
-    console.err(err)
-    res.send('ERROR!')
+    res.status(503)
+    res.send(err)
     return
   }
   res.send(data)
@@ -58,6 +58,7 @@ module.exports = function (proxy) {
       const note = getDefaultNoteFromRequest(req)
       Joi.validate(note, schema, function (err, value) {
         if (err) {
+          res.status(400)
           res.send(err)
           return
         }

--- a/src/controllers/sessionsController.js
+++ b/src/controllers/sessionsController.js
@@ -10,7 +10,7 @@ function mapToSession (data) {
 
 var dataCallback = function (err, data, res) {
   if (err) {
-    console.err(err)
+    res.status(503)    
     res.send(err)
     return
   }
@@ -32,6 +32,7 @@ module.exports = function (proxy) {
       const topics = req.body
       Joi.validate(topics, Joi.array().items(Joi.string()), function (err, value) {
         if (err) {
+          res.status(400)
           res.send(err)
           return
         }


### PR DESCRIPTION
I've added the status code 400 and 503 for some requests which
could fail for note and session.