### PR TITLE
Issue #18 - Check if 'id' exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Server side of StickySessions",
   "main": "index.js",
   "scripts": {
-    "start": "./node_modules/eslint/bin/eslint.js . && nodemon index.js"
+    "start": "./node_modules/eslint/bin/eslint.js . && node index.js"
   },
   "repository": {
     "type": "git",

--- a/src/controllers/sessionsController.js
+++ b/src/controllers/sessionsController.js
@@ -10,7 +10,7 @@ function mapToSession (data) {
 
 var dataCallback = function (err, data, res) {
   if (err) {
-    res.status(503)    
+    res.status(503)
     res.send(err)
     return
   }

--- a/src/environment/FirestoreDB/index.js
+++ b/src/environment/FirestoreDB/index.js
@@ -5,7 +5,7 @@ admin.initializeApp({
 })
 
 const db = admin.firestore()
-const settings = {timestampsInSnapshots: true}
+const settings = { timestampsInSnapshots: true }
 db.settings(settings)
 
 var FieldValue = require('firebase-admin').firestore.FieldValue
@@ -64,7 +64,9 @@ function executeGetDoc (table, docId, callback) {
 function executeAddDoc (table, docData, callback) {
   db.collection(table).add(docData)
     .then(ref => {
-      docData['id'] = ref.id
+      if (ref.id) {
+        docData['id'] = ref.id
+      }
       callback(null, docData)
     })
     .catch(err => {


### PR DESCRIPTION
When the 'id' key wasn't found, an error was being thrown. Now
a check is done.

It fixes #18.