### PR TITLE
Issue #21: Adding user param to get notes endpoint

### DIFF
--- a/src/controllers/notesController.js
+++ b/src/controllers/notesController.js
@@ -49,8 +49,14 @@ module.exports = function (proxy) {
     }
 
     getNotesFromSession (req, res) {
-      var sessionId = req.params.session_id
-      proxy.getNotes(sessionId, res, snapshotCallback)
+      const sessionId = req.params.session_id
+      const user = req.params.user
+      const params = {}
+      params['session_id'] = sessionId
+      if (user) {
+        params['user'] = user
+      }
+      proxy.getNotes(params, res, snapshotCallback)
     }
 
     addNewNoteToSession (req, res) {

--- a/src/controllers/sessionsController.js
+++ b/src/controllers/sessionsController.js
@@ -10,7 +10,7 @@ function mapToSession (data) {
 
 var dataCallback = function (err, data, res) {
   if (err) {
-    res.status(503)    
+    res.status(503)
     res.send(err)
     return
   }

--- a/src/environment/FirestoreDB/index.js
+++ b/src/environment/FirestoreDB/index.js
@@ -5,7 +5,7 @@ admin.initializeApp({
 })
 
 const db = admin.firestore()
-const settings = {timestampsInSnapshots: true}
+const settings = { timestampsInSnapshots: true }
 db.settings(settings)
 
 var FieldValue = require('firebase-admin').firestore.FieldValue
@@ -45,10 +45,14 @@ function executeDocQuery (query, callback) {
     })
 }
 
-function executeGet (table, column, data, callback) {
+function executeGet (table, data, callback) {
   var query = db.collection(table)
+
+  console.log(data)
   if (data) {
-    query = query.where(column, '==', data)
+    for (var item in data) {
+      query = query.where(item, '==', data[item])
+    }
   }
   executeQuery(query, callback)
 }
@@ -72,8 +76,8 @@ function executeAddDoc (table, docData, callback) {
     })
 }
 
-module.exports.getNotes = function (sessionId, callback) {
-  executeGet(tableInfo.table_notes, tableInfo.column_notes_session_id, sessionId, callback)
+module.exports.getNotes = function (params, callback) {
+  executeGet(tableInfo.table_notes, params, callback)
 }
 
 module.exports.getSession = function (sessionId, callback) {

--- a/src/environment/proxy.js
+++ b/src/environment/proxy.js
@@ -3,8 +3,8 @@ class Proxy {
     this.db = db
   }
 
-  getNotes (sessionId, res, callback) {
-    this.db.getNotes(sessionId, (err, snapshot) => {
+  getNotes (params, res, callback) {
+    this.db.getNotes(params, (err, snapshot) => {
       callback(err, snapshot, res)
     })
   }

--- a/src/environment/router/notesRouter.js
+++ b/src/environment/router/notesRouter.js
@@ -2,7 +2,7 @@ const express = require('express')
 var app = express()
 
 module.exports = function (notesController) {
-  app.get('/:session_id', (req, res) => {
+  app.get('/:session_id/:user?', (req, res) => {
     notesController.getNotesFromSession(req, res)
   })
 


### PR DESCRIPTION
Now if when a request is done to '/notes/session_id', a user is
added to the end like '/notes/session_id/author', the database
returns the notes created by that user.

It fixes #21.