### PR TITLE
Issue_24: Creating delete note endpoint

### DIFF
--- a/src/controllers/notesController.js
+++ b/src/controllers/notesController.js
@@ -71,6 +71,18 @@ module.exports = function (proxy) {
         proxy.addNewNoteToSession(value, res, dataCallback)
       })
     }
+
+    deleteNote (req, res) {
+      const noteId = req.params.note_id
+      proxy.deleteNote(noteId, (err, resp) => {
+        if (err) {
+          res.send(err)
+          return
+        }
+        res.status(200)
+        res.send(resp)
+      })
+    }
   }
   return new NotesController(proxy)
 }

--- a/src/environment/FirestoreDB/index.js
+++ b/src/environment/FirestoreDB/index.js
@@ -78,6 +78,16 @@ function executeAddDoc (table, docData, callback) {
     })
 }
 
+function executeDeleteDoc (table, docId, callback) {
+  db.collection(table).doc(docId).delete()
+    .then(resp => {
+      callback(null, resp)
+    })
+    .catch(err => {
+      callback(err, null)
+    })
+}
+
 module.exports.getNotes = function (params, callback) {
   executeGet(tableInfo.table_notes, params, callback)
 }
@@ -96,4 +106,8 @@ module.exports.createSession = function (topics, callback) {
 
 module.exports.addNewNoteToSession = function (note, callback) {
   executeAddDoc(tableInfo.table_notes, note, callback)
+}
+
+module.exports.deleteNote = function (noteId, callback) {
+  executeDeleteDoc(tableInfo.table_notes, noteId, callback)
 }

--- a/src/environment/proxy.js
+++ b/src/environment/proxy.js
@@ -15,6 +15,12 @@ class Proxy {
     })
   }
 
+  deleteNote (noteId, callback) {
+    this.db.deleteNote(noteId, (err, resp) => {
+      callback(err, resp)
+    })
+  }
+
   getSession (sessionId, res, callback) {
     this.db.getSession(sessionId, (err, snapshot) => {
       callback(err, snapshot, res)

--- a/src/environment/router/notesRouter.js
+++ b/src/environment/router/notesRouter.js
@@ -10,5 +10,9 @@ module.exports = function (notesController) {
     notesController.addNewNoteToSession(req, res)
   })
 
+  app.delete('/:note_id', (req, res) => {
+    notesController.deleteNote(req, res)
+  })
+
   return app
 }


### PR DESCRIPTION
When a DELETE is done to the url '/notes/:note_id', the note is
removed from the db.

It fixes #24.