### PR TITLE
Issue #23: Creating get sessions endpoint

### DIFF
--- a/src/controllers/sessionsController.js
+++ b/src/controllers/sessionsController.js
@@ -39,6 +39,17 @@ module.exports = function (proxy) {
         proxy.createSession(value, res, dataCallback)
       })
     }
+
+    getSessions (req, res) {
+      proxy.getSessions((err, sessions) => {
+        if (err) {
+          res.status(503)
+          res.send(err)
+          return
+        }
+        res.send(sessions)
+      })
+    }
   }
   return new SessionsController(proxy)
 }

--- a/src/environment/FirestoreDB/index.js
+++ b/src/environment/FirestoreDB/index.js
@@ -48,7 +48,6 @@ function executeDocQuery (query, callback) {
 function executeGet (table, data, callback) {
   var query = db.collection(table)
 
-  console.log(data)
   if (data) {
     for (var item in data) {
       query = query.where(item, '==', data[item])
@@ -88,8 +87,17 @@ function executeDeleteDoc (table, docId, callback) {
     })
 }
 
-module.exports.getNotes = function (params, callback) {
-  executeGet(tableInfo.table_notes, params, callback)
+module.exports.getSessions = function (callback) {
+  executeGet(tableInfo.table_sessions, null, (err, snapshot) => {
+    if (err) {
+      callback(err, null)
+      return
+    }
+    const mapper = require('./mapper')
+    mapper.mapSnapshotToArray(snapshot, (sessions) => {
+      callback(null, sessions)
+    })
+  })
 }
 
 module.exports.getSession = function (sessionId, callback) {
@@ -102,6 +110,10 @@ module.exports.createSession = function (topics, callback) {
     timestamp: FieldValue.serverTimestamp()
   }
   executeAddDoc(tableInfo.table_sessions, session, callback)
+}
+
+module.exports.getNotes = function (params, callback) {
+  executeGet(tableInfo.table_notes, params, callback)
 }
 
 module.exports.addNewNoteToSession = function (note, callback) {

--- a/src/environment/FirestoreDB/mapper/index.js
+++ b/src/environment/FirestoreDB/mapper/index.js
@@ -1,0 +1,8 @@
+module.exports.mapSnapshotToArray = function (snapshot, callback) {
+  var array = []
+  snapshot.forEach(doc => {
+    var data = doc.data()
+    array.push(data)
+  })
+  callback(array)
+}

--- a/src/environment/proxy.js
+++ b/src/environment/proxy.js
@@ -27,6 +27,10 @@ class Proxy {
     })
   }
 
+  getSessions (callback) {
+    this.db.getSessions(callback)
+  }
+
   createSession (topics, res, callback) {
     this.db.createSession(topics, (err, data) => {
       callback(err, data, res)

--- a/src/environment/router/sessionsRouter.js
+++ b/src/environment/router/sessionsRouter.js
@@ -10,5 +10,9 @@ module.exports = function (sessionsController) {
     sessionsController.createSession(req, res)
   })
 
+  app.get('/', (req, res) => {
+    sessionsController.getSessions(req, res)
+  })
+
   return app
 }


### PR DESCRIPTION
When a GET is called to the url '/sessions/', all of the sessions
in database are returned.

It fixes #23.