### PR TITLE
Issue #27: Status code was not being returned when error occurred

### DIFF
--- a/src/controllers/notesController.js
+++ b/src/controllers/notesController.js
@@ -10,6 +10,7 @@ var snapshotCallback = function (err, snapshot, res) {
   var array = []
   snapshot.forEach(doc => {
     var data = doc.data()
+    data['id'] = doc.id
     array.push(data)
   })
   res.send(array)
@@ -76,10 +77,10 @@ module.exports = function (proxy) {
       const noteId = req.params.note_id
       proxy.deleteNote(noteId, (err, resp) => {
         if (err) {
+          res.status(503)
           res.send(err)
           return
         }
-        res.status(200)
         res.send(resp)
       })
     }

--- a/src/environment/FirestoreDB/mapper/index.js
+++ b/src/environment/FirestoreDB/mapper/index.js
@@ -2,6 +2,7 @@ module.exports.mapSnapshotToArray = function (snapshot, callback) {
   var array = []
   snapshot.forEach(doc => {
     var data = doc.data()
+    data['id'] = doc.id
     array.push(data)
   })
   callback(array)


### PR DESCRIPTION
When the delete method was called and an error ocurred, the status
code was still '200 OK'. Now it's '503 Service Unavailable'.

Also, now IDs of DOCs are being returned.

It fixes #27.