### PR TITLE
Issue #29: Refactoring to remove db dependency of controllers

### DIFF
--- a/src/controllers/notesController.js
+++ b/src/controllers/notesController.js
@@ -1,21 +1,5 @@
 const Joi = require('joi')
 
-var snapshotCallback = function (err, snapshot, res) {
-  if (err) {
-    res.status(503)
-    res.send(err)
-    return
-  }
-
-  var array = []
-  snapshot.forEach(doc => {
-    var data = doc.data()
-    data['id'] = doc.id
-    array.push(data)
-  })
-  res.send(array)
-}
-
 var dataCallback = function (err, data, res) {
   if (err) {
     res.status(503)
@@ -57,7 +41,7 @@ module.exports = function (proxy) {
       if (user) {
         params['user'] = user
       }
-      proxy.getNotes(params, res, snapshotCallback)
+      proxy.getNotes(params, res, dataCallback)
     }
 
     addNewNoteToSession (req, res) {

--- a/src/controllers/sessionsController.js
+++ b/src/controllers/sessionsController.js
@@ -1,6 +1,7 @@
 const Joi = require('joi')
 
 function mapToSession (data) {
+  if (!data) return
   return {
     session_id: data.id,
     topics: data.topics,

--- a/src/environment/FirestoreDB/index.js
+++ b/src/environment/FirestoreDB/index.js
@@ -73,6 +73,7 @@ function executeAddDoc (table, docData, callback) {
       callback(null, docData)
     })
     .catch(err => {
+      console.log('Error adding document', err)
       callback(err, null)
     })
 }
@@ -83,6 +84,7 @@ function executeDeleteDoc (table, docId, callback) {
       callback(null, resp)
     })
     .catch(err => {
+      console.log('Error deleting document', err)
       callback(err, null)
     })
 }
@@ -113,7 +115,17 @@ module.exports.createSession = function (topics, callback) {
 }
 
 module.exports.getNotes = function (params, callback) {
-  executeGet(tableInfo.table_notes, params, callback)
+  executeGet(tableInfo.table_notes, params, (err, snapshot) => {
+    if (err) {
+      callback(err, null)
+      return
+    }
+
+    const mapper = require('./mapper')
+    mapper.mapSnapshotToArray(snapshot, (sessions) => {
+      callback(null, sessions)
+    })
+  })
 }
 
 module.exports.addNewNoteToSession = function (note, callback) {


### PR DESCRIPTION
The class notesController.js does not know anymore the type of
the return of the database data. It only matters the final result,
the notes..

It fixes #29.