### PR TITLE
Issue #34: Limiting number of chars in note

### DIFF
--- a/src/controllers/notesController.js
+++ b/src/controllers/notesController.js
@@ -11,7 +11,7 @@ var dataCallback = function (err, data, res) {
 
 function getDefaultJoiNoteSchema () {
   return Joi.object().keys({
-    description: Joi.string().required(),
+    description: Joi.string().required().max(100),
     user: Joi.string().required(),
     session_id: Joi.string().required(),
     topic: Joi.string().required()


### PR DESCRIPTION
Adding a limiting parameter in the JOI validation to limit
the max number of chars that can be used in the description
of a note.