### PR TITLE
Issue #40: Changing 'session_id' to 'id'

### DIFF
--- a/src/controllers/sessionsController.js
+++ b/src/controllers/sessionsController.js
@@ -3,7 +3,7 @@ const Joi = require('joi')
 function mapToSession (data) {
   if (!data) return
   return {
-    session_id: data.id,
+    id: data.id,
     topics: data.topics,
     timestamp: data.timestamp
   }


### PR DESCRIPTION
Requests were returning different names to the same information and
it was causing confusion on the client-side. Changing it to 'id' so
it's defined a pattern.

It fixes #40.