### PR TITLE
Issue #44: Implementing Create team endpoint

### DIFF
--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,4 +1,5 @@
 module.exports.init = function (proxy) {
   exports.notesController = require('./notesController')(proxy)
   exports.sessionsRouter = require('./sessionsController')(proxy)
+  exports.teamsRouter = require('./teamsController')(proxy)
 }

--- a/src/controllers/teamsController.js
+++ b/src/controllers/teamsController.js
@@ -1,0 +1,43 @@
+const Joi = require('joi')
+
+function getDefaultJoiCreateTeamSchema () {
+  return Joi.object().keys({
+    name: Joi.string().required(),
+    members: Joi.array().items(Joi.string()).required()
+  })
+}
+
+module.exports = function (proxy) {
+  class TeamsController {
+    constructor (proxy) {
+      this.proxy = proxy
+    }
+
+    createTeam (req, res) {
+      const team = req.body
+      Joi.validate(team, getDefaultJoiCreateTeamSchema(), function (err, value) {
+        if (err) {
+          res.status(400)
+          res.send(err)
+          return
+        }
+
+        if (team.members.length === 0) {
+          res.status(400)
+          res.send({ 'message': 'Array of members must not be empty.' })
+          return
+        }
+        proxy.createTeam(value, (err, createdTeam) => {
+          if (err) {
+            console.log(err)
+            res.status(400)
+            res.send(err)
+            return
+          }
+          res.send(createdTeam)
+        })
+      })
+    }
+  }
+  return new TeamsController(proxy)
+}

--- a/src/environment/FirestoreDB/index.js
+++ b/src/environment/FirestoreDB/index.js
@@ -14,7 +14,8 @@ const tableInfo = {
   table_notes: 'notes',
   column_notes_session_id: 'session_id',
   column_notes_description: 'description',
-  table_sessions: 'sessions'
+  table_sessions: 'sessions',
+  table_teams: 'teams'
 }
 
 function executeQuery (query, callback) {
@@ -134,4 +135,24 @@ module.exports.addNewNoteToSession = function (note, callback) {
 
 module.exports.deleteNote = function (noteId, callback) {
   executeDeleteDoc(tableInfo.table_notes, noteId, callback)
+}
+
+module.exports.createTeam = function (team, callback) {
+  const params = {
+    'name': team.name
+  }
+  executeGet(tableInfo.table_teams, params, (err, querySnapshot) => {
+    if (err) {
+      callback(err, null)
+      return
+    }
+    if (querySnapshot._size > 0) {
+      const error = {
+        'message': 'There is already a team with that name. Please, choose another one.'
+      }
+      callback(error)
+      return
+    }
+    executeAddDoc(tableInfo.table_teams, team, callback)
+  })
 }

--- a/src/environment/proxy.js
+++ b/src/environment/proxy.js
@@ -36,6 +36,12 @@ class Proxy {
       callback(err, data, res)
     })
   }
+
+  createTeam (team, callback) {
+    this.db.createTeam(team, (err, team) => {
+      callback(err, team)
+    })
+  }
 }
 
 module.exports = new Proxy()

--- a/src/environment/router/index.js
+++ b/src/environment/router/index.js
@@ -1,5 +1,6 @@
 const notesFromSessionURL = '/notes/'
 const sessionURL = '/sessions/'
+const teamsURL = '/teams/'
 
 module.exports.init = function (app, controllers) {
   const notesRouter = require('./notesRouter')(controllers.notesController)
@@ -7,4 +8,7 @@ module.exports.init = function (app, controllers) {
 
   const sessionsRouter = require('./sessionsRouter')(controllers.sessionsRouter)
   app.use(sessionURL, sessionsRouter)
+
+  const teamsRouter = require('./teamsRouter')(controllers.teamsRouter)
+  app.use(teamsURL, teamsRouter)
 }

--- a/src/environment/router/teamsRouter.js
+++ b/src/environment/router/teamsRouter.js
@@ -1,0 +1,10 @@
+const express = require('express')
+var app = express()
+
+module.exports = function (teamsController) {
+  app.post('/create', (req, res) => {
+    teamsController.createTeam(req, res)
+  })
+
+  return app
+}


### PR DESCRIPTION
To be created, a team is required to have a unique name and a list
with its members. The list cannot be null or empty.

To use this endpoint, you should use the path '/teams/create'.