### PR TITLE
Issue #49: Implement pagination for sessions

### DIFF
--- a/src/controllers/sessionsController.js
+++ b/src/controllers/sessionsController.js
@@ -51,6 +51,19 @@ module.exports = function (proxy) {
         res.send(sessions)
       })
     }
+
+    getSessionsPaging (req, res) {
+      const limit = parseInt(req.params.limit)
+      const milliseconds = req.params.milliseconds
+      proxy.getSessionsPaging(limit, milliseconds, (err, sessions) => {
+        if (err) {
+          res.status(503)
+          res.send(err)
+          return
+        }
+        res.send(sessions)
+      })
+    }
   }
   return new SessionsController(proxy)
 }

--- a/src/environment/proxy.js
+++ b/src/environment/proxy.js
@@ -31,6 +31,10 @@ class Proxy {
     this.db.getSessions(callback)
   }
 
+  getSessionsPaging (limit, milliseconds, callback) {
+    this.db.getSessionsPaging(limit, milliseconds, callback)
+  }
+
   createSession (topics, res, callback) {
     this.db.createSession(topics, (err, data) => {
       callback(err, data, res)

--- a/src/environment/router/sessionsRouter.js
+++ b/src/environment/router/sessionsRouter.js
@@ -14,5 +14,9 @@ module.exports = function (sessionsController) {
     sessionsController.getSessions(req, res)
   })
 
+  app.get('/paging/:limit/:milliseconds?', (req, res) => {
+    sessionsController.getSessionsPaging(req, res)
+  })
+
   return app
 }


### PR DESCRIPTION
Implementing feature that enables pagination for the request that
returns the Sessions. The pagination is being done by timestamp.

To use this feature, you should make a GET request to:
    - '/sessions/:limit/:milliseconds?'