### PR TITLE
Adjust firestore update return type to match other queries

### DIFF
--- a/src/environment/FirestoreDB/index.js
+++ b/src/environment/FirestoreDB/index.js
@@ -21,8 +21,7 @@ const tableInfo = {
 function executeUpdate (table, id, data, callback) {
   db.collection(table).doc(id).update(data)
     .then(snapshot => {
-      data['id'] = id
-      callback(data)
+      executeGetDoc(table, id, callback)
     })
     .catch(err => {
       console.error('Error updating object', err)


### PR DESCRIPTION
Firestore update operation was returning the same type sent to db
instead of the one from db itself after operation was completed. It
was causing a inconsistency on client's side since it needs to handle
different formats for each endpoint, despite information returned be
the same.